### PR TITLE
Add admin accounts

### DIFF
--- a/lib/pet_store/accounts.ex
+++ b/lib/pet_store/accounts.ex
@@ -28,6 +28,16 @@ defmodule PetStore.Accounts do
     Repo.fetch_by(User, email: email)
   end
 
+  def maybe_redacted_user_by_email(email, caller) when is_binary(email) do
+    case fetch_user_by_email(email) do
+      {:ok, %User{admin_level: admin_level} = user} when admin_level < caller.admin_level ->
+        {:ok, user}
+
+      _ ->
+        {:error, :forbidden}
+    end
+  end
+
   @doc """
   Gets a user by email and password.
 

--- a/lib/pet_store/accounts.ex
+++ b/lib/pet_store/accounts.ex
@@ -183,6 +183,16 @@ defmodule PetStore.Accounts do
   end
 
   @doc """
+  Version without password check
+  Used when changing the password for another user.
+  """
+  def apply_user_email(user, email) do
+    user
+    |> User.email_changeset(%{email: email})
+    |> Ecto.Changeset.apply_action(:update)
+  end
+
+  @doc """
   Updates the user email using the given token.
 
   If the token matches, the user email is updated and the token is deleted.

--- a/lib/pet_store/accounts.ex
+++ b/lib/pet_store/accounts.ex
@@ -95,7 +95,17 @@ defmodule PetStore.Accounts do
       {:error, %Ecto.Changeset{}}
 
   """
-  def register_user(attrs, creator \\ nil) do
+  def register_user(attrs) do
+    %User{}
+    |> User.registration_changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Like register user, but should be preferred when registering from the web interface as
+  it checks for adequate admin_level
+  """
+  def try_register_user(attrs, creator \\ nil) do
     max_admin_level = get_in(creator, [Access.key!(:admin_level)]) || 0
 
     %User{}

--- a/lib/pet_store/accounts.ex
+++ b/lib/pet_store/accounts.ex
@@ -103,19 +103,8 @@ defmodule PetStore.Accounts do
 
       iex> register_user(%{field: bad_value})
       {:error, %Ecto.Changeset{}}
-
   """
-  def register_user(attrs) do
-    %User{}
-    |> User.registration_changeset(attrs)
-    |> Repo.insert()
-  end
-
-  @doc """
-  Like register user, but should be preferred when registering from the web interface as
-  it checks for adequate admin_level
-  """
-  def try_register_user(attrs, creator \\ nil) do
+  def register_user(attrs, creator \\ nil) do
     max_admin_level = get_in(creator, [Access.key!(:admin_level)]) || 0
     new_user_admin_level = attrs[:admin_level] || 0
 

--- a/lib/pet_store/accounts.ex
+++ b/lib/pet_store/accounts.ex
@@ -105,7 +105,7 @@ defmodule PetStore.Accounts do
   end
 
   defp maybe_confirm_user(changeset, creator) do
-    if creator,
+    if creator && creator.admin_level > 0,
       do: User.confirm_changeset(changeset),
       else: changeset
   end

--- a/lib/pet_store/accounts.ex
+++ b/lib/pet_store/accounts.ex
@@ -117,11 +117,15 @@ defmodule PetStore.Accounts do
   """
   def try_register_user(attrs, creator \\ nil) do
     max_admin_level = get_in(creator, [Access.key!(:admin_level)]) || 0
+    new_user_admin_level = attrs[:admin_level] || 0
 
-    %User{}
-    |> User.registration_changeset(attrs, max_admin_level: max_admin_level)
-    |> maybe_confirm_user(creator)
-    |> Repo.insert()
+    if new_user_admin_level > max_admin_level,
+      do: {:error, :forbidden},
+      else:
+        %User{}
+        |> User.registration_changeset(attrs)
+        |> maybe_confirm_user(creator)
+        |> Repo.insert()
   end
 
   defp maybe_confirm_user(changeset, creator) do

--- a/lib/pet_store/accounts/user.ex
+++ b/lib/pet_store/accounts/user.ex
@@ -66,7 +66,7 @@ defmodule PetStore.Accounts.User do
     changeset
     |> validate_inclusion(:admin_level, 0..5, message: "invalid range")
     |> validate_number(:admin_level,
-      less_than_or_equal_to: Keyword.get(opts, :max_admin_level, 0),
+      less_than_or_equal_to: Keyword.get(opts, :max_admin_level, 5),
       message: "insufficient permissions"
     )
   end

--- a/lib/pet_store/accounts/user.ex
+++ b/lib/pet_store/accounts/user.ex
@@ -62,7 +62,7 @@ defmodule PetStore.Accounts.User do
     |> maybe_hash_password(opts)
   end
 
-  defp validate_admin_level(changeset, opts) do
+  defp validate_admin_level(changeset, _opts) do
     changeset
     |> validate_inclusion(:admin_level, 0..5, message: "invalid range")
   end

--- a/lib/pet_store/accounts/user.ex
+++ b/lib/pet_store/accounts/user.ex
@@ -6,6 +6,7 @@ defmodule PetStore.Accounts.User do
     field :email, :string
     field :password, :string, virtual: true, redact: true
     field :hashed_password, :string, redact: true
+    field :admin_level, :integer
     field :confirmed_at, :naive_datetime
 
     timestamps()

--- a/lib/pet_store/accounts/user.ex
+++ b/lib/pet_store/accounts/user.ex
@@ -65,10 +65,6 @@ defmodule PetStore.Accounts.User do
   defp validate_admin_level(changeset, opts) do
     changeset
     |> validate_inclusion(:admin_level, 0..5, message: "invalid range")
-    |> validate_number(:admin_level,
-      less_than_or_equal_to: Keyword.get(opts, :max_admin_level, 5),
-      message: "insufficient permissions"
-    )
   end
 
   defp maybe_hash_password(changeset, opts) do

--- a/lib/pet_store/accounts/user.ex
+++ b/lib/pet_store/accounts/user.ex
@@ -37,9 +37,10 @@ defmodule PetStore.Accounts.User do
   """
   def registration_changeset(user, attrs, opts \\ []) do
     user
-    |> cast(attrs, [:email, :password])
+    |> cast(attrs, [:email, :password, :admin_level])
     |> validate_email(opts)
     |> validate_password(opts)
+    |> validate_admin_level(opts)
   end
 
   defp validate_email(changeset, opts) do
@@ -59,6 +60,15 @@ defmodule PetStore.Accounts.User do
     # |> validate_format(:password, ~r/[A-Z]/, message: "at least one upper case character")
     # |> validate_format(:password, ~r/[!?@#$%^&*_0-9]/, message: "at least one digit or punctuation character")
     |> maybe_hash_password(opts)
+  end
+
+  defp validate_admin_level(changeset, opts) do
+    changeset
+    |> validate_inclusion(:admin_level, 0..5, message: "invalid range")
+    |> validate_number(:admin_level,
+      less_than_or_equal_to: Keyword.get(opts, :max_admin_level, 0),
+      message: "insufficient permissions"
+    )
   end
 
   defp maybe_hash_password(changeset, opts) do

--- a/lib/pet_store_web.ex
+++ b/lib/pet_store_web.ex
@@ -89,7 +89,8 @@ defmodule PetStoreWeb do
       defp to_data(%PetStore.Accounts.User{} = user) do
         %{
           id: user.id,
-          email: user.email
+          email: user.email,
+          admin_level: user.admin_level
         }
       end
     end

--- a/lib/pet_store_web/controllers/fallback_controller.ex
+++ b/lib/pet_store_web/controllers/fallback_controller.ex
@@ -14,6 +14,13 @@ defmodule PetStoreWeb.FallbackController do
     |> render(:error, changeset: changeset)
   end
 
+  def call(conn, {:error, :forbidden}) do
+    conn
+    |> put_status(:forbidden)
+    |> put_view(json: PetStoreWeb.ErrorJSON)
+    |> render(:"403")
+  end
+
   # This clause is an example of how to handle resources that cannot be found.
   def call(conn, {:error, :not_found}) do
     conn

--- a/lib/pet_store_web/controllers/user_registration_controller.ex
+++ b/lib/pet_store_web/controllers/user_registration_controller.ex
@@ -11,13 +11,13 @@ defmodule PetStoreWeb.UserRegistrationController do
   def create(%Plug.Conn{assigns: %{current_user: %PetStore.Accounts.User{} = creator}} = conn, %{
         "user" => user_params
       }) do
-    with {:ok, new_user} <- Accounts.try_register_user(user_params, creator) do
+    with {:ok, new_user} <- Accounts.register_user(user_params, creator) do
       render(conn, :data, data: new_user)
     end
   end
 
   def create(conn, %{"user" => user_params}) do
-    with {:ok, user} <- Accounts.try_register_user(user_params) do
+    with {:ok, user} <- Accounts.register_user(user_params) do
       {:ok, _} =
         Accounts.deliver_user_confirmation_instructions(
           user,

--- a/lib/pet_store_web/controllers/user_registration_controller.ex
+++ b/lib/pet_store_web/controllers/user_registration_controller.ex
@@ -13,14 +13,6 @@ defmodule PetStoreWeb.UserRegistrationController do
       }) do
     with {:ok, new_user} <- Accounts.try_register_user(user_params, creator) do
       render(conn, :data, data: new_user)
-    else
-      {:error, %{"errors" => %{"admin_level" => admin}} = changeset} ->
-        if "insufficient permissions" in admin,
-          do: {:error, :forbidden},
-          else: {:error, changeset}
-
-      other ->
-        other
     end
   end
 

--- a/lib/pet_store_web/controllers/user_registration_controller.ex
+++ b/lib/pet_store_web/controllers/user_registration_controller.ex
@@ -6,6 +6,24 @@ defmodule PetStoreWeb.UserRegistrationController do
 
   action_fallback PetStoreWeb.FallbackController
 
+  # Registration made by a user, presumably an admin account
+  # Do not login after creation, it was probably created for someone else
+  def create(%Plug.Conn{assigns: %{current_user: %PetStore.Accounts.User{} = creator}} = conn, %{
+        "user" => user_params
+      }) do
+    with {:ok, new_user} <- Accounts.register_user(user_params, creator) do
+      render(conn, :data, data: new_user)
+    else
+      {:error, %{"errors" => %{"admin_level" => admin}} = changeset} ->
+        if "insufficient permissions" in admin,
+          do: {:error, :forbidden},
+          else: {:error, changeset}
+
+      other ->
+        other
+    end
+  end
+
   def create(conn, %{"user" => user_params}) do
     with {:ok, user} <- Accounts.register_user(user_params) do
       {:ok, _} =
@@ -17,23 +35,6 @@ defmodule PetStoreWeb.UserRegistrationController do
       conn = UserAuth.log_in_user(conn, user)
       token = conn.assigns.user_token
       render(conn, :register, token: token)
-    end
-  end
-
-  # Do not login after creation, it was probably created for someone else
-  def create_admin(conn, %{"user" => user_params}) do
-    current_user = conn.assigns[:current_user]
-
-    with {:ok, new_user} <- Accounts.register_user(user_params, current_user) do
-      render(conn, :data, data: new_user)
-    else
-      {:error, %{"errors" => %{"admin_level" => admin}} = changeset} ->
-        if "insufficient permissions" in admin,
-          do: {:error, :forbidden},
-          else: {:error, changeset}
-
-      other ->
-        other
     end
   end
 end

--- a/lib/pet_store_web/controllers/user_registration_controller.ex
+++ b/lib/pet_store_web/controllers/user_registration_controller.ex
@@ -19,4 +19,21 @@ defmodule PetStoreWeb.UserRegistrationController do
       render(conn, :register, token: token)
     end
   end
+
+  # Do not login after creation, it was probably created for someone else
+  def create_admin(conn, %{"user" => user_params}) do
+    current_user = conn.assigns[:current_user]
+
+    with {:ok, new_user} <- Accounts.register_user(user_params, current_user) do
+      render(conn, :data, data: new_user)
+    else
+      {:error, %{"errors" => %{"admin_level" => admin}} = changeset} ->
+        if "insufficient permissions" in admin,
+          do: {:error, :forbidden},
+          else: {:error, changeset}
+
+      other ->
+        other
+    end
+  end
 end

--- a/lib/pet_store_web/controllers/user_registration_controller.ex
+++ b/lib/pet_store_web/controllers/user_registration_controller.ex
@@ -11,7 +11,7 @@ defmodule PetStoreWeb.UserRegistrationController do
   def create(%Plug.Conn{assigns: %{current_user: %PetStore.Accounts.User{} = creator}} = conn, %{
         "user" => user_params
       }) do
-    with {:ok, new_user} <- Accounts.register_user(user_params, creator) do
+    with {:ok, new_user} <- Accounts.try_register_user(user_params, creator) do
       render(conn, :data, data: new_user)
     else
       {:error, %{"errors" => %{"admin_level" => admin}} = changeset} ->
@@ -25,7 +25,7 @@ defmodule PetStoreWeb.UserRegistrationController do
   end
 
   def create(conn, %{"user" => user_params}) do
-    with {:ok, user} <- Accounts.register_user(user_params) do
+    with {:ok, user} <- Accounts.try_register_user(user_params) do
       {:ok, _} =
         Accounts.deliver_user_confirmation_instructions(
           user,

--- a/lib/pet_store_web/controllers/user_settings_controller.ex
+++ b/lib/pet_store_web/controllers/user_settings_controller.ex
@@ -12,8 +12,7 @@ defmodule PetStoreWeb.UserSettingsController do
   def update(conn, %{"action" => "update_email", "target" => target_email, "value" => new_email}) do
     with {:ok, target} <-
            Accounts.maybe_redacted_user_by_email(target_email, conn.assigns.current_user),
-         email_changeset = Accounts.change_user_email(target, %{email: new_email}),
-         {:ok, new_user} <- Ecto.Changeset.apply_action(email_changeset, :update) do
+         {:ok, new_user} <- Accounts.apply_user_email(target, new_email) do
       token = Accounts.generate_user_token(target)
 
       Accounts.deliver_user_update_email_instructions(

--- a/lib/pet_store_web/router.ex
+++ b/lib/pet_store_web/router.ex
@@ -10,6 +10,7 @@ defmodule PetStoreWeb.Router do
   scope "/", PetStoreWeb do
     pipe_through [:api, :require_authenticated_user]
 
+    post "/users/register_admin", UserRegistrationController, :create_admin
     put "/users/settings", UserSettingsController, :update
     get "/users/settings/confirm_email/:token", UserSettingsController, :confirm_email
 

--- a/lib/pet_store_web/router.ex
+++ b/lib/pet_store_web/router.ex
@@ -8,9 +8,14 @@ defmodule PetStoreWeb.Router do
   end
 
   scope "/", PetStoreWeb do
+    pipe_through [:api, :maybe_authenticate_user]
+
+    post "/users/register", UserRegistrationController, :create
+  end
+
+  scope "/", PetStoreWeb do
     pipe_through [:api, :require_authenticated_user]
 
-    post "/users/register_admin", UserRegistrationController, :create_admin
     put "/users/settings", UserSettingsController, :update
     get "/users/settings/confirm_email/:token", UserSettingsController, :confirm_email
 
@@ -23,7 +28,6 @@ defmodule PetStoreWeb.Router do
     post "/users/confirm", UserConfirmationController, :create
     post "/users/confirm/:token", UserConfirmationController, :update
 
-    post "/users/register", UserRegistrationController, :create
     post "/users/log_in", UserSessionController, :create
     post "/users/reset_password", UserResetPasswordController, :create
     put "/users/reset_password/:token", UserResetPasswordController, :update

--- a/lib/pet_store_web/user_auth.ex
+++ b/lib/pet_store_web/user_auth.ex
@@ -37,9 +37,7 @@ defmodule PetStoreWeb.UserAuth do
   def require_authenticated_user(conn, _opts) do
     case try_authenticate(conn) do
       {:ok, token, user} ->
-        conn
-        |> assign(:current_user, user)
-        |> assign(:user_token, token)
+        insert_auth(conn, token, user)
 
       {:error, status} ->
         conn
@@ -47,6 +45,12 @@ defmodule PetStoreWeb.UserAuth do
         |> send_resp()
         |> halt()
     end
+  end
+
+  defp insert_auth(conn, token, user) do
+    conn
+    |> assign(:current_user, user)
+    |> assign(:user_token, token)
   end
 
   defp try_authenticate(conn) do

--- a/lib/pet_store_web/user_auth.ex
+++ b/lib/pet_store_web/user_auth.ex
@@ -47,6 +47,13 @@ defmodule PetStoreWeb.UserAuth do
     end
   end
 
+  def maybe_authenticate_user(conn, _opts) do
+    case try_authenticate(conn) do
+      {:ok, token, user} -> insert_auth(conn, token, user)
+      _ -> conn
+    end
+  end
+
   defp insert_auth(conn, token, user) do
     conn
     |> assign(:current_user, user)

--- a/priv/repo/migrations/20230508100505_add_admin_level_to_users.exs
+++ b/priv/repo/migrations/20230508100505_add_admin_level_to_users.exs
@@ -3,7 +3,7 @@ defmodule PetStore.Repo.Migrations.AddAdminLevelToUsers do
 
   def up do
     alter table(:users) do
-      add_if_not_exists :admin_level, :integer, null: false, default: 0
+      add :admin_level, :integer, null: false, default: 0
     end
 
     create constraint(:users, :admin_level_range, check: "admin_level >= 0 AND admin_level <= 5")
@@ -13,7 +13,7 @@ defmodule PetStore.Repo.Migrations.AddAdminLevelToUsers do
     drop constraint(:users, :admin_level_range)
 
     alter table(:users) do
-      remove_if_exists :admin_level, :integer
+      remove :admin_level, :integer
     end
   end
 end

--- a/priv/repo/migrations/20230508100505_add_admin_level_to_users.exs
+++ b/priv/repo/migrations/20230508100505_add_admin_level_to_users.exs
@@ -1,19 +1,11 @@
 defmodule PetStore.Repo.Migrations.AddAdminLevelToUsers do
   use Ecto.Migration
 
-  def up do
+  def change do
     alter table(:users) do
       add :admin_level, :integer, null: false, default: 0
     end
 
     create constraint(:users, :admin_level_range, check: "admin_level >= 0 AND admin_level <= 5")
-  end
-
-  def down do
-    drop constraint(:users, :admin_level_range)
-
-    alter table(:users) do
-      remove :admin_level, :integer
-    end
   end
 end

--- a/priv/repo/migrations/20230508100505_add_admin_level_to_users.exs
+++ b/priv/repo/migrations/20230508100505_add_admin_level_to_users.exs
@@ -1,7 +1,19 @@
 defmodule PetStore.Repo.Migrations.AddAdminLevelToUsers do
   use Ecto.Migration
 
-  def change do
+  def up do
+    alter table(:users) do
+      add_if_not_exists :admin_level, :integer, null: false, default: 0
+    end
 
+    create constraint(:users, :admin_level_range, check: "admin_level >= 0 AND admin_level <= 5")
+  end
+
+  def down do
+    drop constraint(:users, :admin_level_range)
+
+    alter table(:users) do
+      remove_if_exists :admin_level, :integer
+    end
   end
 end

--- a/priv/repo/migrations/20230508100505_add_admin_level_to_users.exs
+++ b/priv/repo/migrations/20230508100505_add_admin_level_to_users.exs
@@ -1,0 +1,7 @@
+defmodule PetStore.Repo.Migrations.AddAdminLevelToUsers do
+  use Ecto.Migration
+
+  def change do
+
+  end
+end

--- a/test/pet_store/accounts_test.exs
+++ b/test/pet_store/accounts_test.exs
@@ -109,6 +109,25 @@ defmodule PetStore.AccountsTest do
       assert is_nil(user.confirmed_at)
       assert is_nil(user.password)
     end
+
+    test "can register admin user" do
+      admin_level = 2
+      creator = %User{admin_level: admin_level}
+      user_attrs = valid_user_attributes(admin_level: admin_level)
+      {:ok, user} = Accounts.register_user(user_attrs, creator)
+      assert user.admin_level == admin_level
+    end
+
+    test "cannot register an admin level higher than itself" do
+      creator_level = 1
+      new_level = creator_level + 1
+
+      creator = %User{admin_level: creator_level}
+      user_attrs = valid_user_attributes(admin_level: new_level)
+      {:error, changeset} = Accounts.register_user(user_attrs, creator)
+
+      assert "insufficient permissions" in errors_on(changeset).admin_level
+    end
   end
 
   describe "change_user_registration/2" do

--- a/test/pet_store/accounts_test.exs
+++ b/test/pet_store/accounts_test.exs
@@ -116,6 +116,7 @@ defmodule PetStore.AccountsTest do
       user_attrs = valid_user_attributes(admin_level: admin_level)
       {:ok, user} = Accounts.register_user(user_attrs, creator)
       assert user.admin_level == admin_level
+      assert user.confirmed_at
     end
 
     test "cannot register an admin level higher than itself" do
@@ -127,6 +128,14 @@ defmodule PetStore.AccountsTest do
       {:error, changeset} = Accounts.register_user(user_attrs, creator)
 
       assert "insufficient permissions" in errors_on(changeset).admin_level
+    end
+
+    test "normal user doesn't confirm newly created user" do
+      creator = %User{admin_level: 0}
+
+      user_attrs = valid_user_attributes()
+      {:ok, user} = Accounts.register_user(user_attrs, creator)
+      refute user.confirmed_at
     end
   end
 

--- a/test/pet_store/accounts_test.exs
+++ b/test/pet_store/accounts_test.exs
@@ -109,12 +109,59 @@ defmodule PetStore.AccountsTest do
       assert is_nil(user.confirmed_at)
       assert is_nil(user.password)
     end
+  end
+
+  describe "try_register_user/2" do
+    test "requires email and password to be set" do
+      {:error, changeset} = Accounts.try_register_user(%{})
+
+      assert %{
+               password: ["can't be blank"],
+               email: ["can't be blank"]
+             } = errors_on(changeset)
+    end
+
+    test "validates email and password when given" do
+      {:error, changeset} =
+        Accounts.try_register_user(%{email: "not valid", password: "not valid"})
+
+      assert %{
+               email: ["must have the @ sign and no spaces"],
+               password: ["should be at least 12 character(s)"]
+             } = errors_on(changeset)
+    end
+
+    test "validates maximum values for email and password for security" do
+      too_long = String.duplicate("db", 100)
+      {:error, changeset} = Accounts.try_register_user(%{email: too_long, password: too_long})
+      assert "should be at most 160 character(s)" in errors_on(changeset).email
+      assert "should be at most 72 character(s)" in errors_on(changeset).password
+    end
+
+    test "validates email uniqueness" do
+      %{email: email} = user_fixture()
+      {:error, changeset} = Accounts.try_register_user(%{email: email})
+      assert "has already been taken" in errors_on(changeset).email
+
+      # Now try with the upper cased email too, to check that email case is ignored.
+      {:error, changeset} = Accounts.try_register_user(%{email: String.upcase(email)})
+      assert "has already been taken" in errors_on(changeset).email
+    end
+
+    test "registers users with a hashed password" do
+      email = unique_user_email()
+      {:ok, user} = Accounts.try_register_user(valid_user_attributes(email: email))
+      assert user.email == email
+      assert is_binary(user.hashed_password)
+      assert is_nil(user.confirmed_at)
+      assert is_nil(user.password)
+    end
 
     test "can register admin user" do
       admin_level = 2
       creator = %User{admin_level: admin_level}
       user_attrs = valid_user_attributes(admin_level: admin_level)
-      {:ok, user} = Accounts.register_user(user_attrs, creator)
+      {:ok, user} = Accounts.try_register_user(user_attrs, creator)
       assert user.admin_level == admin_level
       assert user.confirmed_at
     end
@@ -125,7 +172,7 @@ defmodule PetStore.AccountsTest do
 
       creator = %User{admin_level: creator_level}
       user_attrs = valid_user_attributes(admin_level: new_level)
-      {:error, changeset} = Accounts.register_user(user_attrs, creator)
+      {:error, changeset} = Accounts.try_register_user(user_attrs, creator)
 
       assert "insufficient permissions" in errors_on(changeset).admin_level
     end
@@ -134,7 +181,7 @@ defmodule PetStore.AccountsTest do
       creator = %User{admin_level: 0}
 
       user_attrs = valid_user_attributes()
-      {:ok, user} = Accounts.register_user(user_attrs, creator)
+      {:ok, user} = Accounts.try_register_user(user_attrs, creator)
       refute user.confirmed_at
     end
   end

--- a/test/pet_store/accounts_test.exs
+++ b/test/pet_store/accounts_test.exs
@@ -193,9 +193,7 @@ defmodule PetStore.AccountsTest do
 
       creator = %User{admin_level: creator_level}
       user_attrs = valid_user_attributes(admin_level: new_level)
-      {:error, changeset} = Accounts.try_register_user(user_attrs, creator)
-
-      assert "insufficient permissions" in errors_on(changeset).admin_level
+      assert {:error, :forbidden} == Accounts.try_register_user(user_attrs, creator)
     end
 
     test "normal user doesn't confirm newly created user" do

--- a/test/pet_store/accounts_test.exs
+++ b/test/pet_store/accounts_test.exs
@@ -17,6 +17,27 @@ defmodule PetStore.AccountsTest do
     end
   end
 
+  describe "maybe_redacted_user_by_email/2" do
+    test "does not return the user if the email does not exist" do
+      caller = %User{admin_level: 5}
+
+      assert {:error, :forbidden} =
+               Accounts.maybe_redacted_user_by_email("unknown@example.com", caller)
+    end
+
+    test "returns the user if the email exists and the caller has suffcient permissions" do
+      %{id: id} = user = user_fixture()
+      caller = %User{admin_level: 2}
+      assert {:ok, %User{id: ^id}} = Accounts.maybe_redacted_user_by_email(user.email, caller)
+    end
+
+    test "does not return the user if the email exists but the caller does not have suffcient permissions" do
+      user = user_fixture()
+      caller = %User{admin_level: 0}
+      assert {:error, :forbidden} = Accounts.maybe_redacted_user_by_email(user.email, caller)
+    end
+  end
+
   describe "fetch_user_by_email_and_password/2" do
     test "does not return the user if the email does not exist" do
       assert {:error, :not_found} =

--- a/test/pet_store_web/controllers/user_registration_controller_test.exs
+++ b/test/pet_store_web/controllers/user_registration_controller_test.exs
@@ -40,5 +40,19 @@ defmodule PetStoreWeb.UserRegistrationControllerTest do
       assert "must have the @ sign and no spaces" in errors["email"]
       assert "should be at least 12 character(s)" in errors["password"]
     end
+
+    test "doesn't log the user in if already authenticated", %{conn: conn} do
+      %{conn: conn} = register_and_log_in_user(%{conn: conn})
+
+      email = unique_user_email()
+
+      conn =
+        post(conn, ~p"/users/register", %{
+          "user" => valid_user_attributes(email: email)
+        })
+
+      response = json_response(conn, 200)
+      assert response["data"]["email"] == email
+    end
   end
 end

--- a/test/pet_store_web/controllers/user_settings_controller_test.exs
+++ b/test/pet_store_web/controllers/user_settings_controller_test.exs
@@ -94,8 +94,8 @@ defmodule PetStoreWeb.UserSettingsControllerTest do
     end
 
     test "does not update user email without enough permissions", %{conn: conn, user: user} do
-      admin = PetStore.AccountsFixtures.user_fixture(admin_level: 0)
-      conn = log_in_user(conn, admin)
+      normal_user = PetStore.AccountsFixtures.user_fixture(admin_level: 0)
+      conn = log_in_user(conn, normal_user)
 
       conn =
         put(conn, ~p"/users/settings", %{

--- a/test/pet_store_web/controllers/user_settings_controller_test.exs
+++ b/test/pet_store_web/controllers/user_settings_controller_test.exs
@@ -75,6 +75,37 @@ defmodule PetStoreWeb.UserSettingsControllerTest do
       assert "is not valid" in errors["current_password"]
       assert "must have the @ sign and no spaces" in errors["email"]
     end
+
+    test "updates another user's email if lower admin level", %{conn: conn, user: user} do
+      admin = PetStore.AccountsFixtures.user_fixture(admin_level: 2)
+      conn = log_in_user(conn, admin)
+
+      conn =
+        put(conn, ~p"/users/settings", %{
+          "action" => "update_email",
+          "target" => user.email,
+          "value" => unique_user_email()
+        })
+
+      assert json_response(conn, 200)["message"] =~
+               "A link to confirm your email"
+
+      assert {:ok, _} = Accounts.fetch_user_by_email(user.email)
+    end
+
+    test "does not update user email without enough permissions", %{conn: conn, user: user} do
+      admin = PetStore.AccountsFixtures.user_fixture(admin_level: 0)
+      conn = log_in_user(conn, admin)
+
+      conn =
+        put(conn, ~p"/users/settings", %{
+          "action" => "update_email",
+          "target" => user.email,
+          "value" => unique_user_email()
+        })
+
+      assert json_response(conn, 403)
+    end
   end
 
   describe "GET /users/settings/confirm_email/:token" do

--- a/test/support/fixture/accounts_fixture.ex
+++ b/test/support/fixture/accounts_fixture.ex
@@ -16,10 +16,12 @@ defmodule PetStore.AccountsFixtures do
   end
 
   def user_fixture(attrs \\ %{}) do
+    valid_attrs = valid_user_attributes(attrs)
+
     {:ok, user} =
-      attrs
-      |> valid_user_attributes()
-      |> PetStore.Accounts.register_user()
+      %PetStore.Accounts.User{}
+      |> PetStore.Accounts.User.registration_changeset(valid_attrs)
+      |> PetStore.Repo.insert()
 
     user
   end

--- a/test/support/fixture/accounts_fixture.ex
+++ b/test/support/fixture/accounts_fixture.ex
@@ -10,7 +10,8 @@ defmodule PetStore.AccountsFixtures do
   def valid_user_attributes(attrs \\ %{}) do
     Enum.into(attrs, %{
       email: unique_user_email(),
-      password: valid_user_password()
+      password: valid_user_password(),
+      admin_level: 0
     })
   end
 


### PR DESCRIPTION
Admins are special accounts that can create other accounts without needing confirmation, up to their admin_level and edit user accounts of a level lower than them.

In the future they will be used to insert new pets in the database.

Admins are implemented as an admin level 0..5 instead of a simple flag, to (possibly) allow more granular control over the resources.